### PR TITLE
Add Link to Use Local Database

### DIFF
--- a/src/main/java/com/sample/springboot/PostController.java
+++ b/src/main/java/com/sample/springboot/PostController.java
@@ -2,6 +2,7 @@ package com.sample.springboot;
 
 import com.sample.utils.LoggerPost;
 import com.sample.utils.LoginInfo;
+import com.sample.utils.PostDB;
 
 import javax.servlet.http.HttpSession;
 import javax.servlet.http.HttpServletRequest;
@@ -62,7 +63,7 @@ public class PostController {
         if (login.jumpHost == "") {
             login.jumpHost = null; login.jumpUser = null; login.jumpPass = null;
         }
-        pl.Login(login);
+        pl.Login(login, PostDB.MARIADB_DRIVER);
         model.addAttribute("isLoggedIn", pl.GetLoggedIn());
         if (!pl.GetLoggedIn())
             model.addAttribute("loginFailed", true);
@@ -70,6 +71,15 @@ public class PostController {
             return "index";
 
         return "login";
+    }
+
+    @RequestMapping(value = "/login_local")
+    public String LoginLocal(Model model, HttpSession sesh, HttpServletRequest req) {
+      LoggerPost pl = getLogger(sesh);
+      LoginInfo login = new LoginInfo("", "", "", "", null, null, null);
+      pl.Login(login, PostDB.H2_DRIVER);
+      model.addAttribute("isLoggedIn", pl.GetLoggedIn());
+      return "index";
     }
 
     @RequestMapping(value = "/logout")

--- a/src/main/java/com/sample/utils/LoggerPost.java
+++ b/src/main/java/com/sample/utils/LoggerPost.java
@@ -20,8 +20,8 @@ public class LoggerPost {
         }
     }
 
-    public void Login(LoginInfo login) {
-        db.Login(login);
+    public void Login(LoginInfo login, String driver) {
+        db.Login(login, driver);
     }
 
     public void Logout() {

--- a/src/main/java/com/sample/utils/PostDB.java
+++ b/src/main/java/com/sample/utils/PostDB.java
@@ -22,12 +22,6 @@ public class PostDB {
         this.known_hosts_path = known_hosts_path;
     }
 
-    public void Login(LoginInfo login) {
-        this.login = login;
-        this.dbDriver = MARIADB_DRIVER;
-        connect();
-    }
-
     public void Login(LoginInfo login, String driver) {
         this.login = login;
         this.dbDriver = driver;

--- a/src/main/resources/templates/blocks/header.html
+++ b/src/main/resources/templates/blocks/header.html
@@ -9,6 +9,8 @@
             <th:block th:if="${!isLoggedIn}">
                 You aren't logged in. Log in
                 <a href="/login">here</a>.
+                Use a local database instead
+                <a href="/login_local">here</a>.
             </th:block>
             <th:block th:if="${isLoggedIn}">
                 You are currently logged in.


### PR DESCRIPTION
Previously an unused option existed in the code to use H2, an in-memory database for the DB operations. This was never exposed anywhere, and still required users to "sign in".

This commit adds a new link (and corresponding method) to use H2 instead of signing in, modifying the header. All functionality should otherwise be identical.